### PR TITLE
fix(cli): Cli era el entryponit erroneamente, se paso a main.py #20

### DIFF
--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete principal de fast-pdf."""

--- a/dev/main.py
+++ b/dev/main.py
@@ -3,8 +3,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from beanie import init_beanie
 
-from dev.server.config import settings
-from dev.server.models.database import get_client
+from dev.config import settings
+from dev.servers.models.database import get_client
 from dev.models import Pdf
 
 
@@ -34,3 +34,20 @@ def create_app() -> FastAPI:
     return app
 
 app = create_app()
+
+
+def main() -> int:
+    """Entry-point principal del programa.
+
+    Llama al CLI para procesar PDFs desde línea de comandos.
+    """
+    import sys
+    from dev.cli import main as cli_main
+
+    return cli_main()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/dev/servers/models/database.py
+++ b/dev/servers/models/database.py
@@ -1,5 +1,5 @@
 from motor.motor_asyncio import AsyncIOMotorClient
-from dev.server.config import settings
+from dev.config import settings
 
 
 def get_client() -> AsyncIOMotorClient:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 description = "API para gestión de documentos PDF"
 readme = "README.md"
 requires-python = ">=3.12"
-
-[project.scripts]
-fast-pdf = "dev.cli:main"
-
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
@@ -21,6 +17,9 @@ dependencies = [
     "pytest-asyncio>=1.3.0",
     "httpx>=0.28.1",
 ]
+
+[project.scripts]
+fast-pdf = "dev.main:main"
 
 [project.optional-dependencies]
 dev = [
@@ -36,4 +35,4 @@ build-backend = "hatchling.build"
 packages = ["dev"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["test"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,14 +8,9 @@ from pathlib import Path
 from typing import Generator
 
 import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
 
 # Configurar PYTHONPATH para importar dev
 sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from dev.models import Base
 
 
 # Upload directory fixture
@@ -51,56 +46,3 @@ def sample_pdf_bytes() -> bytes:
         b"0000000101 00000 n\n0000000270 00000 n\n"
         b"trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n369\n%%EOF\n"
     )
-
-
-# FastAPI app fixture with overridden dependencies
-@pytest.fixture(scope="function")
-def client(temp_upload_dir: Path) -> Generator[TestClient, None, None]:
-    """Proporciona un TestClient con base de datos y directorio de uploads sobreescritos."""
-    from dev.models import Base as TestBase
-    from dev.config import settings
-
-    # Guardar valores originales
-    original_upload_dir = settings.UPLOAD_DIR
-
-    # Override settings
-    settings.UPLOAD_DIR = str(temp_upload_dir)
-
-    # Crear motor de base de datos en memoria
-    test_engine = create_engine(
-        "sqlite:///:memory:", connect_args={"check_same_thread": False}
-    )
-    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
-    TestBase.metadata.create_all(bind=test_engine)
-
-    # Función para obtener sesión de BD de prueba
-    def get_test_db():
-        db = TestSessionLocal()
-        try:
-            yield db
-        finally:
-            db.close()
-
-    # Importar el módulo main y crear la app manualmente
-    from dev.main import create_app
-    from dev import database
-
-    # Sobrescribir el engine en el módulo database
-    original_engine = database.engine
-    database.engine = test_engine
-
-    # Crear la aplicación (esto usará el engine modificado)
-    app = create_app()
-
-    # Sobrescribir la dependencia get_db usando dependency_overrides
-    from dev.database import get_db
-
-    app.dependency_overrides[get_db] = get_test_db
-
-    with TestClient(app) as test_client:
-        yield test_client
-
-    # Cleanup: restaurar valores originales
-    database.engine = original_engine
-    settings.UPLOAD_DIR = original_upload_dir
-    TestBase.metadata.drop_all(bind=test_engine)

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -22,7 +22,7 @@ class TestCliArguments:
 
         # Act & Assert: El CLI debe ejecutarse sin error de argumentos
         result = subprocess.run(
-            [sys.executable, "-m", "dev.cli", str(pdf_file)],
+            [sys.executable, "-m", "dev.main", str(pdf_file)],
             capture_output=True,
             text=True,
         )
@@ -46,7 +46,7 @@ class TestPdfStorage:
 
         # Act: Ejecutar CLI que debería guardar en MongoDB
         result = subprocess.run(
-            [sys.executable, "-m", "dev.cli", str(pdf_file)],
+            [sys.executable, "-m", "dev.main", str(pdf_file)],
             capture_output=True,
             text=True,
         )
@@ -79,7 +79,7 @@ class TestPdfToText:
 
         # Act: Ejecutar CLI
         result = subprocess.run(
-            [sys.executable, "-m", "dev.cli", str(pdf_file)],
+            [sys.executable, "-m", "dev.main", str(pdf_file)],
             capture_output=True,
             text=True,
         )

--- a/test/unit/test_main_entry_point.py
+++ b/test/unit/test_main_entry_point.py
@@ -1,0 +1,33 @@
+"""Tests para verificar el entry-point main.py."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+class TestMainEntryPoint:
+    """Tests que verifican que main.py es el entry-point correcto."""
+
+    def test_main_module_has_main_function(self) -> None:
+        """El módulo main debe exportar una función main()."""
+        # Act & Assert: Importar main desde dev.main no debe fallar
+        from dev.main import main
+
+        assert callable(main), "main debe ser una función callable"
+
+    def test_main_module_can_be_executed(self, tmp_path: Path) -> None:
+        """El módulo main debe ejecutarse sin errores de importación."""
+        # Arrange: Crear PDF de prueba
+        pdf_file = tmp_path / "test.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake pdf content")
+
+        # Act: Ejecutar main.py con un archivo PDF
+        result = subprocess.run(
+            [sys.executable, "-m", "dev.main", str(pdf_file)],
+            capture_output=True,
+            text=True,
+        )
+
+        # Assert: No debe fallar por errores de importación (código 2)
+        # Puede fallar por archivo no encontrado o MongoDB, pero no por import
+        assert result.returncode != 2, f"Error de importación: {result.stderr}"


### PR DESCRIPTION
### Problema
En mi anterior pull request olvide que el entryponit del programa apuntaba en cli.py, lo cual era incorrecto y rompía responsabilidades. 

### Solucion
Arregle eso y arregle la ruta de ejecución en uv "fast-pdf = "dev.main:main"" Ahora la app se puede ejecutar con: "uv run fast-pdf" o solo fast-pdf  si el entorno esta configurado.

### Otros
- También se añadió un una flag con ayuda minima y los tests correspondientes.
- Algunos archivos de test y otros usaban dependencias viejas.