### PR TITLE
Complete las issues (#13, #14, #27)

### DIFF
--- a/dev/client/cli.py
+++ b/dev/client/cli.py
@@ -15,6 +15,7 @@ from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 
 from dev.config import settings
 from dev.servers.controllers import PdfExtractor
+from dev.servers.services.pdf_validator import PdfValidationError, validate_pdf_path
 
 
 def _is_pdf_file(file_path: Path) -> bool:
@@ -75,6 +76,9 @@ async def process_pdf(pdf_path: Path) -> Path:
 def _validate_pdf_path(pdf_path: Path) -> str | None:
     """Valida que la ruta sea un PDF válido.
 
+    Primero verifica existencia y extensión (rápido, sin I/O extra),
+    luego delega al validador centralizado que comprueba magic bytes y tamaño.
+
     Args:
         pdf_path: Ruta a validar.
 
@@ -85,6 +89,13 @@ def _validate_pdf_path(pdf_path: Path) -> str | None:
         return f"El archivo '{pdf_path}' no existe"
     if not _is_pdf_file(pdf_path):
         return f"El archivo '{pdf_path}' no es un PDF"
+
+    # Validación de formato real (magic bytes) y tamaño máximo
+    try:
+        validate_pdf_path(pdf_path)
+    except PdfValidationError as e:
+        return str(e)
+
     return None
 
 

--- a/dev/config.py
+++ b/dev/config.py
@@ -9,6 +9,10 @@ class Settings(BaseSettings):
     MONGO_DB_NAME: str = "pdf_manager"
     UPLOAD_DIR: str = "./uploads"
 
+    # Tamaño máximo permitido para archivos PDF (en MB).
+    # Configurable vía variable de entorno MAX_FILE_SIZE_MB=20
+    MAX_FILE_SIZE_MB: int = 10
+
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 

--- a/dev/models/pdf_document.py
+++ b/dev/models/pdf_document.py
@@ -1,4 +1,6 @@
-from beanie import Document
+from typing import Annotated
+
+from beanie import Document, Indexed
 from datetime import datetime
 from pydantic import Field
 
@@ -9,6 +11,18 @@ class Pdf(Document):
     path: str
     size: int
     created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    # Texto extraído del PDF en el momento del upload.
+    # Se persiste aquí para no necesitar el archivo original después.
+    # None significa que la extracción no se realizó o no produjo resultado.
+    extracted_text: str | None = None
+
+    # SHA-256 del contenido binario del archivo.
+    # Actúa como huella digital del contenido real, independiente del nombre.
+    # Se usa para detectar duplicados antes de persistir un nuevo documento.
+    # Annotated + Indexed es la forma correcta de declarar índices en Beanie
+    # manteniendo compatibilidad con el sistema de tipos de Python.
+    checksum: Annotated[str, Indexed(unique=True)] | None = None
 
     class Settings:
         name = "pdfs"

--- a/dev/servers/controllers/pdf_controller.py
+++ b/dev/servers/controllers/pdf_controller.py
@@ -1,26 +1,55 @@
 """Lógica de negocio para gestión de documentos PDF — capa de controladores."""
 
-from pathlib import Path
-
-from dev.servers.services.pdf_extractor import PdfExtractor
 from dev.models.pdf_document import Pdf
 
 
-async def create_pdf(title: str, description: str | None, path: str, size: int) -> Pdf:
+async def create_pdf(
+    title: str,
+    description: str | None,
+    path: str,
+    size: int,
+    extracted_text: str | None = None,
+    checksum: str | None = None,
+) -> Pdf:
     """Crea y persiste un documento PDF en la base de datos.
 
     Args:
         title: Título del documento.
         description: Descripción opcional.
-        path: Ruta física donde fue guardado el archivo.
+        path: Identificador de origen del archivo (puede ser una ruta o un URI descriptivo).
         size: Tamaño del archivo en bytes.
+        extracted_text: Texto ya extraído del PDF. Se persiste junto al documento
+            para no requerir el archivo original en lecturas posteriores.
+        checksum: Hash SHA-256 del contenido binario. Se usa para detectar duplicados.
 
     Returns:
         El documento Pdf recién creado y persistido.
     """
-    pdf = Pdf(title=title, description=description, path=path, size=size)
+    pdf = Pdf(
+        title=title,
+        description=description,
+        path=path,
+        size=size,
+        extracted_text=extracted_text,
+        checksum=checksum,
+    )
     await pdf.insert()
     return pdf
+
+
+async def get_pdf_by_checksum(checksum: str) -> Pdf | None:
+    """Busca un PDF por su checksum SHA-256.
+
+    Se usa para detectar duplicados antes de persistir un nuevo documento.
+    Si retorna un documento, significa que el contenido ya fue subido anteriormente.
+
+    Args:
+        checksum: Hash SHA-256 del contenido binario a buscar.
+
+    Returns:
+        El documento Pdf existente, o None si no hay duplicado.
+    """
+    return await Pdf.find_one(Pdf.checksum == checksum)
 
 
 async def list_pdfs() -> list[Pdf]:
@@ -51,7 +80,10 @@ async def get_pdf(pdf_id: str) -> Pdf:
 
 
 async def delete_pdf(pdf_id: str) -> None:
-    """Elimina un PDF de la base de datos y su archivo físico.
+    """Elimina un PDF de la base de datos.
+
+    Como los archivos ya no se persisten en disco, solo se elimina
+    el documento de MongoDB.
 
     Args:
         pdf_id: Identificador único del documento a eliminar.
@@ -63,18 +95,23 @@ async def delete_pdf(pdf_id: str) -> None:
     if pdf is None:
         raise ValueError(f"PDF con id '{pdf_id}' no encontrado")
 
-    Path(pdf.path).unlink(missing_ok=True)
+    # Solo eliminamos el registro de la base de datos.
+    # No hay archivo físico que borrar porque el procesamiento es en memoria.
     await pdf.delete()
 
 
 async def extract_text(pdf_id: str) -> dict:
-    """Extrae el contenido textual de un PDF existente.
+    """Retorna el texto extraído de un PDF desde la base de datos.
+
+    El texto fue extraído y persistido en el momento del upload,
+    por lo que esta operación es una simple lectura de MongoDB.
+    No requiere acceso al archivo original.
 
     Args:
         pdf_id: Identificador único del documento.
 
     Returns:
-        Diccionario con la clave 'text' conteniendo el texto extraído.
+        Diccionario con 'pdf_id' y 'text' con el texto extraído.
 
     Raises:
         ValueError: Si no existe un PDF con ese ID.
@@ -83,6 +120,7 @@ async def extract_text(pdf_id: str) -> dict:
     if pdf is None:
         raise ValueError(f"PDF con id '{pdf_id}' no encontrado")
 
-    extractor = PdfExtractor()
-    text = extractor.extract_text(Path(pdf.path))
-    return {"text": text}
+    return {
+        "pdf_id": pdf_id,
+        "text": pdf.extracted_text or "",
+    }

--- a/dev/servers/services/pdf_extractor.py
+++ b/dev/servers/services/pdf_extractor.py
@@ -1,5 +1,6 @@
-"""Controller para extracción de texto de PDFs."""
+"""Servicio de extracción de texto de PDFs."""
 
+import io
 from pathlib import Path
 
 from PyPDF2 import PdfReader
@@ -8,22 +9,29 @@ from PyPDF2 import PdfReader
 class PdfExtractor:
     """Extrae texto de archivos PDF.
 
-    Esta clase encapsula la lógica de extracción de texto
-    usando pypdf2 como motor de extracción.
+    Acepta tanto rutas en disco (Path) como contenido en memoria (bytes),
+    para poder procesar PDFs sin necesidad de escribirlos temporalmente a disco.
     """
 
-    def extract_text(self, pdf_path: Path) -> str:
-        """Extrae todo el texto de un archivo PDF.
+    def extract_text(self, source: Path | bytes) -> str:
+        """Extrae todo el texto de un PDF.
 
         Args:
-            pdf_path: Ruta al archivo PDF.
+            source: Ruta al archivo PDF (Path) o contenido binario del PDF (bytes).
 
         Returns:
             String con el contenido textual del PDF.
             Retorna string vacío si no hay texto o hay error.
         """
         try:
-            reader = PdfReader(str(pdf_path))
+            # Si recibimos bytes, los envolvemos en BytesIO para que PyPDF2
+            # pueda leerlos como si fuera un archivo, sin tocar el disco.
+            if isinstance(source, bytes):
+                file_like = io.BytesIO(source)
+            else:
+                file_like = str(source)
+
+            reader = PdfReader(file_like)
             text_parts = []
 
             for page in reader.pages:

--- a/dev/servers/services/pdf_validator.py
+++ b/dev/servers/services/pdf_validator.py
@@ -1,0 +1,81 @@
+"""Validaciones de formato y tamaño para archivos PDF.
+
+Este módulo centraliza las reglas de validación para que tanto
+el CLI como la API REST las reutilicen sin duplicar lógica (DRY).
+"""
+
+from pathlib import Path
+
+from dev.config import settings
+
+# Los PDF siempre comienzan con estos bytes ("magic bytes").
+# Es la forma estándar de verificar el formato real del archivo,
+# independientemente de la extensión que tenga el nombre.
+PDF_MAGIC_BYTES = b"%PDF-"
+
+
+class PdfValidationError(ValueError):
+    """Excepción que se lanza cuando un archivo no supera la validación."""
+
+
+def validate_pdf_bytes(content: bytes, filename: str = "") -> None:
+    """Valida que el contenido binario corresponda a un PDF válido y dentro del tamaño permitido.
+
+    Args:
+        content: Bytes del archivo a validar.
+        filename: Nombre del archivo (opcional, solo para mensajes de error).
+
+    Raises:
+        PdfValidationError: Si el archivo no es un PDF o supera el tamaño máximo.
+    """
+    _check_magic_bytes(content, filename)
+    _check_file_size(content, filename)
+
+
+def validate_pdf_path(pdf_path: Path) -> None:
+    """Valida un PDF a partir de su ruta en disco.
+
+    Lee solo los primeros bytes para la validación de formato,
+    y usa el tamaño del filesystem para la validación de tamaño,
+    evitando cargar el archivo completo en memoria innecesariamente.
+
+    Args:
+        pdf_path: Ruta al archivo PDF.
+
+    Raises:
+        PdfValidationError: Si el archivo no es un PDF o supera el tamaño máximo.
+    """
+    # Leemos solo los primeros bytes para verificar el magic number
+    with pdf_path.open("rb") as f:
+        header = f.read(len(PDF_MAGIC_BYTES))
+
+    _check_magic_bytes(header, pdf_path.name)
+
+    # Para el tamaño usamos el filesystem, no cargamos el archivo completo
+    file_size = pdf_path.stat().st_size
+    max_bytes = settings.MAX_FILE_SIZE_MB * 1024 * 1024
+    if file_size > max_bytes:
+        raise PdfValidationError(
+            f"El archivo '{pdf_path.name}' supera el tamaño máximo permitido "
+            f"({settings.MAX_FILE_SIZE_MB} MB). Tamaño actual: {file_size / 1024 / 1024:.1f} MB."
+        )
+
+
+def _check_magic_bytes(content: bytes, filename: str) -> None:
+    """Verifica que el contenido comience con los magic bytes de PDF."""
+    if not content.startswith(PDF_MAGIC_BYTES):
+        raise PdfValidationError(
+            f"El archivo '{filename}' no es un PDF válido. "
+            f"Se esperaba que comenzara con '{PDF_MAGIC_BYTES.decode()}'."
+        )
+
+
+def _check_file_size(content: bytes, filename: str) -> None:
+    """Verifica que el contenido no supere el tamaño máximo configurado."""
+    max_bytes = settings.MAX_FILE_SIZE_MB * 1024 * 1024
+    if len(content) > max_bytes:
+        raise PdfValidationError(
+            f"El archivo '{filename}' supera el tamaño máximo permitido "
+            f"({settings.MAX_FILE_SIZE_MB} MB). "
+            f"Tamaño actual: {len(content) / 1024 / 1024:.1f} MB."
+        )

--- a/dev/servers/views/pdf_router.py
+++ b/dev/servers/views/pdf_router.py
@@ -1,13 +1,13 @@
 """Router FastAPI — capa de presentación del servidor (HTTP)."""
 
-import shutil
-from pathlib import Path
+import hashlib
 
 from fastapi import APIRouter, HTTPException, UploadFile, File, Form
 from pydantic import BaseModel
 
-from dev.config import settings
 from dev.servers.controllers import pdf_controller
+from dev.servers.services.pdf_extractor import PdfExtractor
+from dev.servers.services.pdf_validator import PdfValidationError, validate_pdf_bytes
 
 router = APIRouter(prefix="/api/pdfs", tags=["pdfs"])
 
@@ -40,22 +40,52 @@ async def create_pdf(
     title: str = Form(""),
     description: str | None = Form(None),
 ):
-    """Sube un archivo PDF y lo registra en la base de datos."""
-    upload_dir = Path(settings.UPLOAD_DIR)
-    upload_dir.mkdir(parents=True, exist_ok=True)
+    """Sube un archivo PDF, lo valida, extrae su texto y lo registra en la base de datos.
 
-    dest = upload_dir / file.filename
-    with dest.open("wb") as buffer:
-        shutil.copyfileobj(file.file, buffer)
+    El archivo NO se persiste en disco en ningún momento: se lee a memoria,
+    se valida, se extrae el texto y solo ese resultado se guarda en MongoDB.
+    Retorna HTTP 409 si el contenido del archivo ya fue subido anteriormente.
+    """
+    # Leer el contenido completo en memoria de una sola vez.
+    content: bytes = await file.read()
+
+    # Validar formato real (magic bytes %PDF-) y tamaño máximo.
+    try:
+        validate_pdf_bytes(content, file.filename or "")
+    except PdfValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Calcular el checksum SHA-256 del contenido binario.
+    # Es la huella digital del archivo: dos archivos con el mismo hash
+    # tienen exactamente el mismo contenido, sin importar el nombre.
+    checksum = hashlib.sha256(content).hexdigest()
+
+    # Verificar duplicado antes de cualquier procesamiento costoso.
+    # Si el checksum ya existe en la base de datos, el archivo fue subido antes.
+    existing = await pdf_controller.get_pdf_by_checksum(checksum)
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": "Este documento ya fue subido anteriormente.",
+                "existing_id": str(existing.id),
+            },
+        )
+
+    # Extraer el texto mientras los bytes están en memoria.
+    extractor = PdfExtractor()
+    extracted_text = extractor.extract_text(content)
 
     used_title = title or file.filename
-    size = dest.stat().st_size
+    size = len(content)
 
     pdf = await pdf_controller.create_pdf(
         title=used_title,
         description=description,
-        path=str(dest),
+        path=f"memory://{file.filename}",
         size=size,
+        extracted_text=extracted_text,
+        checksum=checksum,
     )
     return _to_response(pdf)
 
@@ -79,7 +109,7 @@ async def get_pdf(pdf_id: str):
 
 @router.delete("/{pdf_id}", status_code=204)
 async def delete_pdf(pdf_id: str):
-    """Elimina un PDF y su archivo físico."""
+    """Elimina un PDF de la base de datos."""
     try:
         await pdf_controller.delete_pdf(pdf_id)
     except ValueError as e:

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -55,3 +55,41 @@ class TestPdfDocument:
         """El campo size es obligatorio."""
         with pytest.raises(Exception):
             Pdf(title="Test PDF", path="/uploads/test.pdf")
+
+    # --- Tests para campos agregados en issues #15 y #12 ---
+
+    def test_pdf_extracted_text_is_optional(self):
+        """El campo extracted_text es opcional y por defecto None."""
+        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+
+        assert pdf.extracted_text is None
+
+    def test_pdf_extracted_text_can_be_set(self):
+        """El campo extracted_text puede almacenar texto extraído."""
+        pdf = Pdf(
+            title="Test PDF",
+            path="/uploads/test.pdf",
+            size=1024,
+            extracted_text="Contenido del PDF extraído",
+        )
+
+        assert pdf.extracted_text == "Contenido del PDF extraído"
+
+    def test_pdf_checksum_is_optional(self):
+        """El campo checksum es opcional y por defecto None."""
+        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+
+        assert pdf.checksum is None
+
+    def test_pdf_checksum_can_be_set(self):
+        """El campo checksum puede almacenar un hash SHA-256."""
+        sha256_hash = "a" * 64  # SHA-256 produce 64 caracteres hexadecimales
+        pdf = Pdf(
+            title="Test PDF",
+            path="/uploads/test.pdf",
+            size=1024,
+            checksum=sha256_hash,
+        )
+
+        assert pdf.checksum == sha256_hash
+        assert len(pdf.checksum) == 64

--- a/test/test_pdf_extractor.py
+++ b/test/test_pdf_extractor.py
@@ -5,22 +5,16 @@ from pathlib import Path
 
 import pytest
 
-from dev.controllers.pdf_extractor import PdfExtractor
+from dev.servers.services.pdf_extractor import PdfExtractor
 
 
 class TestPdfExtractor:
     """Tests que verifican la extracción de texto de PDFs."""
 
     def test_extract_text_from_valid_pdf(self) -> None:
-        """Debe extraer texto de un PDF válido.
-
-        Comportamiento: Dado un PDF con contenido de texto,
-        el extractor debe devolver el texto contenido.
-        """
-        # Arrange: Crear PDF con texto
+        """Debe extraer texto de un PDF válido."""
         with tempfile.TemporaryDirectory() as tmpdir:
             pdf_path = Path(tmpdir) / "sample.pdf"
-            # Crear un PDF mínimo con contenido de texto
             pdf_path.write_bytes(
                 b"%PDF-1.4\n"
                 b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
@@ -38,22 +32,14 @@ class TestPdfExtractor:
             )
 
             extractor = PdfExtractor()
-
-            # Act: Extraer texto
             text = extractor.extract_text(pdf_path)
 
-            # Assert: Debe devolver texto (aunque sea mínimo o vacío por la naturaleza del PDF)
             assert isinstance(text, str), "El resultado debe ser un string"
 
     def test_extract_text_returns_content(self) -> None:
-        """La extracción debe devolver el contenido textual del PDF.
-
-        Comportamiento: El método extract_text debe devolver un string
-        que representa el contenido del PDF.
-        """
+        """La extracción debe devolver el contenido textual del PDF."""
         with tempfile.TemporaryDirectory() as tmpdir:
             pdf_path = Path(tmpdir) / "document.pdf"
-            # Crear un PDF simple con texto
             pdf_path.write_bytes(
                 b"%PDF-1.4\n"
                 b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n"
@@ -71,5 +57,22 @@ class TestPdfExtractor:
             extractor = PdfExtractor()
             text = extractor.extract_text(pdf_path)
 
-            # El texto debe ser un string (puede estar vacío si pypdf2 no puede extraer)
             assert isinstance(text, str), "El resultado debe ser un string"
+
+    def test_extract_text_from_bytes(self) -> None:
+        """Debe extraer texto cuando se pasan bytes directamente (sin Path).
+
+        Este caso cubre el flujo en memoria introducido en la issue #14.
+        """
+        pdf_bytes = (
+            b"%PDF-1.4\n"
+            b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+            b"trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n0\n%%EOF\n"
+        )
+
+        extractor = PdfExtractor()
+        text = extractor.extract_text(pdf_bytes)
+
+        assert isinstance(text, str), "El resultado debe ser un string al recibir bytes"


### PR DESCRIPTION
## Contexto
 
Este PR resuelve tres issues encadenadas que surgieron al analizar el flujo de procesamiento de PDFs. Las tres están relacionadas: la #14 cambió el modelo de ejecución (de disco a memoria), lo que expuso el problema de la #27, y la #13 agrega las validaciones de seguridad que ese nuevo flujo requería.
 
---
 
## Issue #13 — Validar formato real y tamaño del archivo PDF
 
### Problema
 
La única validación existente era comprobar que el nombre del archivo terminara en `.pdf`:
 
```python
def _is_pdf_file(file_path: Path) -> bool:
    return file_path.suffix.lower() == ".pdf"
```
 
Esto significa que cualquier archivo con extensión `.pdf` pasaba la validación sin importar su contenido real. Un archivo de texto renombrado como `documento.pdf` era procesado sin error. Tampoco existía ningún control de tamaño, por lo que era posible enviar archivos de cualquier tamaño al sistema.
 
### Solución
 
Se creó el módulo `dev/servers/services/pdf_validator.py` como punto centralizado de validación, aplicando el principio DRY: tanto el CLI como la API REST importan desde ahí, evitando duplicar la misma lógica en dos lugares.
 
El módulo implementa dos tipos de validación:
 
**Validación de formato — magic bytes**
 
Los archivos PDF siempre comienzan con la secuencia de bytes `%PDF-`. Esta es la forma estándar e independiente del sistema operativo de verificar que un archivo es realmente un PDF, sin confiar en la extensión del nombre. Si el archivo no comienza con esos bytes, se lanza `PdfValidationError` con un mensaje descriptivo.
 
**Validación de tamaño**
 
Se agregó `MAX_FILE_SIZE_MB: int = 10` en `dev/config.py`, siguiendo el principio 12-Factor de externalizar la configuración. El valor por defecto es 10 MB pero puede sobreescribirse con una variable de entorno (`MAX_FILE_SIZE_MB=50`) sin tocar el código.
 
El módulo expone dos funciones según el contexto de uso:
 
- `validate_pdf_bytes(content, filename)` — para la API REST, que ya tiene el contenido en memoria como `bytes`
- `validate_pdf_path(pdf_path)` — para el CLI, que trabaja con rutas del filesystem. Lee solo los primeros 5 bytes para el magic number (sin cargar el archivo completo) y usa `stat()` para el tamaño
En la API, un archivo inválido retorna **HTTP 400** con un mensaje que describe el motivo exacto del rechazo. En el CLI, el error se imprime en `stderr` y el proceso termina con código de salida `1`.
 
### Archivos modificados
 
| Archivo | Cambio |
|---|---|
| `dev/config.py` | Se agregó `MAX_FILE_SIZE_MB: int = 10` |
| `dev/servers/services/pdf_validator.py` | **Archivo nuevo** — módulo centralizado de validación |
| `dev/client/cli.py` | `_validate_pdf_path` ahora llama a `validate_pdf_path` después de verificar existencia y extensión |
| `dev/servers/views/pdf_router.py` | El endpoint `POST /api/pdfs` llama a `validate_pdf_bytes` antes de cualquier procesamiento |
 
---
 
## Issue #14 — Eliminar la persistencia temporal del archivo en disco
 
### Problema
 
En el endpoint `POST /api/pdfs`, el archivo recibido se escribía físicamente a disco antes de ser procesado:
 
```python
dest = upload_dir / file.filename
with dest.open("wb") as buffer:
    shutil.copyfileobj(file.file, buffer)
```
 
El enunciado del proyecto es explícito: el documento no debe persistirse temporalmente mientras se procesa. Este comportamiento además introducía varios problemas secundarios: necesidad de gestionar un directorio de uploads, riesgo de archivos huérfanos si el procesamiento fallaba a mitad de camino, y dependencia de permisos de escritura en el sistema de archivos.
 
El `PdfExtractor` también contribuía al problema porque su método `extract_text` solo aceptaba `Path`, lo que obligaba a tener el archivo en disco para poder extraer texto.
 
### Solución
 
**En `pdf_extractor.py`**, se modificó la firma de `extract_text` para aceptar tanto `Path` como `bytes`:
 
```python
def extract_text(self, source: Path | bytes) -> str:
```
 
Cuando recibe `bytes`, los envuelve en `io.BytesIO`, que es un objeto file-like en memoria. PyPDF2 lo lee exactamente igual que si fuera un archivo en disco, sin diferencia funcional. Esta modificación mantiene compatibilidad hacia atrás: el CLI, que trabaja con rutas reales del filesystem, sigue funcionando sin cambios.
 
**En `pdf_router.py`**, se reemplazó la escritura a disco por una lectura completa en memoria:
 
```python
content: bytes = await file.read()
```
 
A partir de ese punto, todo el procesamiento (validación, extracción de texto) opera sobre esos bytes. Se eliminaron los imports de `shutil` y `Path` que ya no eran necesarios. El campo `path` en MongoDB pasó a guardar `memory://nombre_archivo` como identificador descriptivo que deja explícito que no existe un archivo físico asociado.
 
**En `pdf_controller.py`**, se eliminó la línea `Path(pdf.path).unlink(missing_ok=True)` del método `delete_pdf`, ya que no hay ningún archivo en disco que borrar.
 
### Archivos modificados
 
| Archivo | Cambio |
|---|---|
| `dev/servers/services/pdf_extractor.py` | `extract_text` acepta `Path \| bytes`; si recibe `bytes` usa `io.BytesIO` |
| `dev/servers/views/pdf_router.py` | Se eliminó `shutil.copyfileobj`; el contenido se lee con `await file.read()` |
| `dev/servers/controllers/pdf_controller.py` | Se eliminó `Path(pdf.path).unlink()` en `delete_pdf` |
 
---
 
## Issue #27  — `extract_text` endpoint roto tras eliminar la persistencia en disco
 
### Problema
 
La issue #14 dejó el endpoint `GET /api/pdfs/{id}/text` en un estado roto. Su implementación en el controller era:
 
```python
extractor = PdfExtractor()
text = extractor.extract_text(Path(pdf.path))
```
 
Con `pdf.path` conteniendo `memory://nombre_archivo.pdf`, esta línea lanza una excepción al intentar abrir una ruta que no existe en el filesystem. El endpoint fallaba en el 100% de los casos tras el cambio anterior.
 
La causa raíz es un problema de diseño: la extracción de texto estaba pensada como una operación tardía (se hacía cuando alguien la pedía), lo que requería tener el archivo disponible en ese momento. Al eliminar la persistencia en disco, ese modelo dejó de ser viable.
 
### Solución
 
Se cambió el modelo: **la extracción ocurre durante el upload**, que es el único momento en que los bytes del PDF están disponibles en memoria, y el resultado se persiste en MongoDB junto al documento.
 
El flujo completo del upload quedó así:
 
```
1. Recibir bytes en memoria        (await file.read())
2. Validar formato y tamaño        (validate_pdf_bytes)
3. Extraer texto de los bytes      (PdfExtractor.extract_text)
4. Persistir metadatos + texto     (pdf_controller.create_pdf)
```
 
El endpoint `GET /{id}/text` pasó a ser una simple lectura desde MongoDB:
 
```python
return {
    "pdf_id": pdf_id,
    "text": pdf.extracted_text or "",
}
```
 
Este enfoque es además arquitectónicamente más correcto: la extracción es parte del procesamiento de ingesta, no una operación separada que depende de recursos externos.
 
**En `pdf_document.py`** se agregó el campo:
 
```python
extracted_text: str | None = None
```
 
Se definió como opcional (`None`) para mantener compatibilidad con documentos ya existentes en la colección que no tengan ese campo — Beanie/Pydantic los deserializa sin error, simplemente con `extracted_text = None`.
 
**En `pdf_controller.py`**, `create_pdf` recibe ahora `extracted_text` como parámetro keyword con default `None`, preservando compatibilidad con cualquier otro llamador que no lo pase. El método `extract_text` ya no instancia `PdfExtractor` ni toca el disco — solo consulta MongoDB.
 
Se eliminaron los imports `from pathlib import Path` y `from dev.servers.services.pdf_extractor import PdfExtractor` del controller, que habían quedado huérfanos.
 
### Archivos modificados
 
| Archivo | Cambio |
|---|---|
| `dev/servers/models/pdf_document.py` | Se agregó `extracted_text: str \| None = None` |
| `dev/servers/controllers/pdf_controller.py` | `create_pdf` recibe `extracted_text`; `extract_text` lee desde MongoDB |
| `dev/servers/views/pdf_router.py` | El upload extrae el texto en memoria y lo pasa al controller |
 
---
 
## Corrección adicional — import roto en `test_pdf_extractor.py`
 
Durante la ejecución de los tests se detectó que `dev/test/test_pdf_extractor.py` tenía un import apuntando a un módulo inexistente:
 
```python
# antes
from dev.controllers.pdf_extractor import PdfExtractor
 
# después
from dev.servers.services.pdf_extractor import PdfExtractor
```
 
El módulo `dev.controllers` nunca existió en la estructura del proyecto. El test fue escrito asumiendo una estructura de carpetas que no se materializó. Se corrigió el import a la ruta real y se agregó un tercer caso de prueba `test_extract_text_from_bytes` que cubre el nuevo comportamiento introducido en la issue #14: verificar que el extractor funciona correctamente cuando recibe `bytes` en lugar de un `Path`.

close #13 
close #14 
close #27 