### PR TITLE
fix(models): eliminacion de path y limpieza de dependencias #31 #36

### DIFF
--- a/dev/models/pdf_document.py
+++ b/dev/models/pdf_document.py
@@ -8,7 +8,6 @@ from pydantic import Field
 class Pdf(Document):
     title: str
     description: str | None = None
-    path: str
     size: int
     created_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/dev/servers/controllers/pdf_controller.py
+++ b/dev/servers/controllers/pdf_controller.py
@@ -6,7 +6,6 @@ from dev.models.pdf_document import Pdf
 async def create_pdf(
     title: str,
     description: str | None,
-    path: str,
     size: int,
     extracted_text: str | None = None,
     checksum: str | None = None,
@@ -16,7 +15,6 @@ async def create_pdf(
     Args:
         title: Título del documento.
         description: Descripción opcional.
-        path: Identificador de origen del archivo (puede ser una ruta o un URI descriptivo).
         size: Tamaño del archivo en bytes.
         extracted_text: Texto ya extraído del PDF. Se persiste junto al documento
             para no requerir el archivo original en lecturas posteriores.
@@ -28,7 +26,6 @@ async def create_pdf(
     pdf = Pdf(
         title=title,
         description=description,
-        path=path,
         size=size,
         extracted_text=extracted_text,
         checksum=checksum,

--- a/dev/servers/views/pdf_router.py
+++ b/dev/servers/views/pdf_router.py
@@ -19,9 +19,6 @@ class PdfResponse(BaseModel):
     size: int
     created_at: str
 
-    class Config:
-        from_attributes = True
-
 
 def _to_response(pdf) -> PdfResponse:
     """Convierte un documento Pdf al esquema de respuesta HTTP."""
@@ -82,7 +79,6 @@ async def create_pdf(
     pdf = await pdf_controller.create_pdf(
         title=used_title,
         description=description,
-        path=f"memory://{file.filename}",
         size=size,
         extracted_text=extracted_text,
         checksum=checksum,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,9 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
     "motor>=3.3.0,<3.7",
     "beanie>=1.24.0,<1.27",
-    "pymongo>=4.6.0,<4.13",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "pypdf2>=3.0.0",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=1.3.0",
-    "httpx>=0.28.1",
     "python-multipart>=0.0.26",
 ]
 
@@ -24,8 +20,9 @@ fast-pdf = "dev.main:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0.0",
-    "httpx>=0.27.0",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+    "httpx>=0.28.1",
 ]
 
 [build-system]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -13,27 +13,25 @@ class TestPdfDocument:
         pdf = Pdf(
             title="Test PDF",
             description="Test description",
-            path="/uploads/test.pdf",
             size=1024,
         )
 
         assert pdf.title == "Test PDF"
         assert pdf.description == "Test description"
-        assert pdf.path == "/uploads/test.pdf"
         assert pdf.size == 1024
 
     def test_pdf_has_auto_generated_created_at(self):
         """El campo created_at se asigna automáticamente al instanciar un PDF."""
         before_creation = datetime.utcnow()
 
-        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+        pdf = Pdf(title="Test PDF", size=1024)
 
         assert pdf.created_at is not None
         assert pdf.created_at >= before_creation
 
     def test_pdf_description_is_optional(self):
         """El campo description es opcional y puede ser None."""
-        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+        pdf = Pdf(title="Test PDF", size=1024)
 
         assert pdf.description is None
 
@@ -44,23 +42,18 @@ class TestPdfDocument:
     def test_pdf_title_is_required(self):
         """El campo title es obligatorio."""
         with pytest.raises(Exception):
-            Pdf(path="/uploads/test.pdf", size=1024)
-
-    def test_pdf_path_is_required(self):
-        """El campo path es obligatorio."""
-        with pytest.raises(Exception):
-            Pdf(title="Test PDF", size=1024)
+            Pdf(size=1024)
 
     def test_pdf_size_is_required(self):
         """El campo size es obligatorio."""
         with pytest.raises(Exception):
-            Pdf(title="Test PDF", path="/uploads/test.pdf")
+            Pdf(title="Test PDF")
 
     # --- Tests para campos agregados en issues #15 y #12 ---
 
     def test_pdf_extracted_text_is_optional(self):
         """El campo extracted_text es opcional y por defecto None."""
-        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+        pdf = Pdf(title="Test PDF", size=1024)
 
         assert pdf.extracted_text is None
 
@@ -68,7 +61,6 @@ class TestPdfDocument:
         """El campo extracted_text puede almacenar texto extraído."""
         pdf = Pdf(
             title="Test PDF",
-            path="/uploads/test.pdf",
             size=1024,
             extracted_text="Contenido del PDF extraído",
         )
@@ -77,16 +69,15 @@ class TestPdfDocument:
 
     def test_pdf_checksum_is_optional(self):
         """El campo checksum es opcional y por defecto None."""
-        pdf = Pdf(title="Test PDF", path="/uploads/test.pdf", size=1024)
+        pdf = Pdf(title="Test PDF", size=1024)
 
         assert pdf.checksum is None
 
     def test_pdf_checksum_can_be_set(self):
         """El campo checksum puede almacenar un hash SHA-256."""
-        sha256_hash = "a" * 64  # SHA-256 produce 64 caracteres hexadecimales
+        sha256_hash = "a" * 64
         pdf = Pdf(
             title="Test PDF",
-            path="/uploads/test.pdf",
             size=1024,
             checksum=sha256_hash,
         )


### PR DESCRIPTION
# Cambios de rama

## fix(models): eliminar campo `path` del modelo Pdf — Issue #31

- Se eliminó el campo `path` de `pdf_document.py`
- Se eliminó el parámetro `path` de `create_pdf()` en `pdf_controller.py`
- Se eliminó `path=f"memory://..."` del llamado al controller en `pdf_router.py`
- Se actualizaron los tests en `test_models.py` eliminando referencias a `path`

## fix(deps): limpiar dependencias — Issue #36

- Se eliminó `pymongo` de dependencias de producción (es transitiva de beanie)
- Se movió `pytest`, `pytest-asyncio` e `httpx` a `[optional-dependencies] dev`