### PR TITLE
fix(cli): se agrego la opcion dowload y la documentacion respectiva #35 #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Este proyecto busca resolver problemas comunes como:
 
 ## Requisitos previos
 
-El programa se inicia levantando mongoDB en docker y en una terminal aparte fastAPI.
-
 - Python 3.12
 - uv
 - Docker
@@ -41,16 +39,16 @@ uv sync
 
 ---
 
-### Cómo levantar el proyecto
+### Levantar el proyecto
 
-#### 1. Primera vez levantando el proyecto
+#### 1. Levantar y crear contenedor
 
 ```bash
 # Construye e inicia en segundo plano (detached)
 docker compose -f .devcontainer/docker-compose.yml up -d --build
 ```
 
-#### 2. Para bajar el contenedor
+#### 2. Bajar el contenedor
 
 ```bash
 # Detiene los servicios sin borrarlos.
@@ -63,7 +61,7 @@ docker compose -f .devcontainer/docker-compose.yml down
 docker compose -f .devcontainer/docker-compose.yml down -v
 ```
 
-#### 3. Para leventar el proyecto por segunda vez o mas veces
+#### 3. Levantar el contenedor ya creado
 
 ```bash
 # En caso de que se haya eliminado el contenedor o eliminado. 
@@ -75,6 +73,29 @@ docker compose -f .devcontainer/docker-compose.yml up -d --build
 # En caso de que el contenedor este guardado.
 docker compose -f .devcontainer/docker-compose.yml start
 ```
+---
+
+## Uso de de la herramienta
+
+Una vez levantado docker y sincronizado uv se puede usar directamente con: `fast-pdf [comando]` en caso
+de que falle, se puede usar `uv run fast-pdf [comando]` para minimizar errores. Se puede usar `fast-pdf -h` 
+para ayuda.
+
+### Comandos
+
+```bash
+Comandos:
+  upload    - Sube un archivo PDF al servidor.
+  list      - Lista todos los documentos PDF persistidos.
+  get       - Muestra el texto extraído de un PDF.
+  delete    - Elimina un documento PDF.
+  download  - Descarga el texto extraído de un PDF como archivo .txt.
+Flags:
+  -h --help - Muesta ayuda.
+  --output archivo.txt - Usando en download permite renombrar el archivo de salida.
+```
+
+---
 
 ## Arquitectura
 
@@ -123,15 +144,16 @@ En este proyecto se utiliza **MongoDB** como sistema de almacenamiento.
 
 A continuación se describe la estructura principal del repositorio:
 
-| Carpeta / Archivo | Descripción |
-|------------------|-------------|
-| `dev/` | Código fuente principal del proyecto |
-| `tests/` | Pruebas automatizadas del sistema |
-| `upload` | Zonas de pruebas |
-| `README.md` | Documentación principal del repositorio |
-| `pyproject.toml` | Dependencias del proyecto |
-| `.gitignore` | Archivos ignorados por Git |
-| `Makefile` | Archivo Makefile para la automatización | 
+
+| Carpeta / Archivo | Descripción                             |
+| ------------------- | ------------------------------------------ |
+| `dev/`            | Código fuente principal del proyecto    |
+| `tests/`          | Pruebas automatizadas del sistema        |
+| `upload/`         | carpeta de pruebas                       |
+| `README.md`       | Documentación principal del repositorio |
+| `pyproject.toml`  | Dependencias del proyecto                |
+| `.gitignore`      | Archivos ignorados por Git               |
+| `.devcontainer/`  | Configuracion para lanzar contenedor     |
 
 Esta organización permite mantener una separación clara entre código, pruebas y documentación.
 
@@ -141,19 +163,15 @@ Esta organización permite mantener una separación clara entre código, pruebas
 
 El proyecto utiliza diversas tecnologías para el procesamiento y análisis de documentos:
 
-- **Python**  
+- **Python**
   Lenguaje principal de desarrollo.
-
-- **UV**  
+- **UV**
   Herramienta moderna para la gestión de dependencias y entornos Python.
-
-- **Inteligencia Artificial (IA)**  
+- **Inteligencia Artificial (IA)**
   Utilizada para análisis avanzado del contenido extraído.
-
-- **OpenCode**  
+- **OpenCode**
   Herramienta utilizada dentro del flujo de desarrollo.
-
-- **MongoDB**  
+- **MongoDB**
   Base de datos NoSQL utilizada para almacenar la información extraída.
 
 ---
@@ -188,16 +206,16 @@ Algunos principios aplicados incluyen:
 
 El proyecto también sigue principios clásicos de diseño de software:
 
-**KISS (Keep It Simple, Stupid)**  
+**KISS (Keep It Simple, Stupid)**
 Mantener el código simple y fácil de entender.
 
-**DRY (Don't Repeat Yourself)**  
+**DRY (Don't Repeat Yourself)**
 Evitar duplicación de lógica en el código.
 
-**YAGNI (You Aren't Gonna Need It)**  
+**YAGNI (You Aren't Gonna Need It)**
 Implementar solo lo necesario.
 
-**SOLID**  
+**SOLID**
 Conjunto de principios para diseño orientado a objetos que mejora la mantenibilidad del software.
 
 ---

--- a/README.md
+++ b/README.md
@@ -77,23 +77,36 @@ docker compose -f .devcontainer/docker-compose.yml start
 
 ## Uso de de la herramienta
 
-Una vez levantado docker y sincronizado uv se puede usar directamente con: `fast-pdf [comando]` en caso
-de que falle, se puede usar `uv run fast-pdf [comando]` para minimizar errores. Se puede usar `fast-pdf -h` 
+Una vez levantado docker y sincronizado uv se puede usar directamente con: `fast-pdf <comando>` en caso
+de que falle, se puede usar `uv run fast-pdf <comando>` para minimizar errores. Se puede usar `fast-pdf -h` 
 para ayuda.
 
 ### Comandos
 
 ```bash
 Comandos:
-  upload    - Sube un archivo PDF al servidor.
-  list      - Lista todos los documentos PDF persistidos.
-  get       - Muestra el texto extraído de un PDF.
-  delete    - Elimina un documento PDF.
-  download  - Descarga el texto extraído de un PDF como archivo .txt.
+
+  # Sube un archivo PDF al servidor.
+  upload <direccion_archivo>
+
+  # Lista todos los documentos PDF persistidos.
+  list
+
+  # Muestra el texto extraído de un PDF por consola.
+  get <id_pdf>
+
+  # Elimina un documento PDF del servidor. 
+  delete <id_pdf>
+
+  # Descarga el texto extraído de un PDF como archivo .txt
+  download <id_pdf>
+
 Flags:
-  -h --help - Muesta ayuda.
-  --output archivo.txt - Usando en download permite renombrar el archivo de salida.
-```
+
+  -h --help
+  
+  # Usando en download permite renombrar el archivo de salida.
+  --output <nombre_archivo.txt> 
 
 ---
 

--- a/dev/client/cli.py
+++ b/dev/client/cli.py
@@ -195,6 +195,46 @@ def _cmd_delete(args: argparse.Namespace) -> int:
         return 1
 
 
+def _cmd_download(args: argparse.Namespace) -> int:
+    """Descarga el texto extraído de un PDF y lo guarda en disco.
+
+    Args:
+        args: Namespace con 'pdf_id' (str) y 'output' (Path | None).
+
+    Returns:
+        Código de salida (0 = éxito, 1 = error).
+    """
+    try:
+        response = httpx.get(f"{_API_PDFS}/{args.pdf_id}/download")
+
+        if response.status_code == 404:
+            print(f"Error: No existe un PDF con ID '{args.pdf_id}'.", file=sys.stderr)
+            return 1
+
+        response.raise_for_status()
+
+        # Determinar nombre del archivo de salida
+        if args.output:
+            output_path = args.output
+        else:
+            # Extraer nombre del header Content-Disposition
+            disposition = response.headers.get("content-disposition", "")
+            filename = "documento.txt"
+            if 'filename="' in disposition:
+                filename = disposition.split('filename="')[1].rstrip('"')
+            output_path = Path(filename)
+
+        output_path.write_text(response.text, encoding="utf-8")
+        print(f"Texto guardado en: {output_path}")
+        return 0
+
+    except httpx.ConnectError:
+        print(
+            f"Error: No se pudo conectar con la API en '{settings.API_BASE_URL}'.",
+            file=sys.stderr,
+        )
+        return 1
+
 # ---------------------------------------------------------------------------
 # Parseo de argumentos
 # ---------------------------------------------------------------------------
@@ -262,6 +302,23 @@ def _parse_arguments() -> argparse.Namespace:
         type=str,
         help="ID del documento a eliminar",
     )
+    
+    # --- download ---
+    download_parser = subparsers.add_parser(
+        "download",
+        help="Descarga el texto extraído de un PDF como archivo .txt",
+    )
+    download_parser.add_argument(
+        "pdf_id",
+        type=str,
+        help="ID del documento",
+    )
+    download_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Nombre del archivo de salida (default: título del documento)",
+    )
 
     return parser.parse_args()
 
@@ -277,6 +334,7 @@ _COMMANDS = {
     "list": _cmd_list,
     "get": _cmd_get,
     "delete": _cmd_delete,
+    "download": _cmd_download,
 }
 
 

--- a/dev/servers/views/pdf_router.py
+++ b/dev/servers/views/pdf_router.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from dev.servers.controllers import pdf_controller
 from dev.servers.services.pdf_extractor import PdfExtractor
 from dev.servers.services.pdf_validator import PdfValidationError, validate_pdf_bytes
+from fastapi.responses import PlainTextResponse
 
 router = APIRouter(prefix="/api/pdfs", tags=["pdfs"])
 
@@ -119,3 +120,22 @@ async def extract_text(pdf_id: str):
         return await pdf_controller.extract_text(pdf_id)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+ 
+    
+@router.get("/{pdf_id}/download", response_class=PlainTextResponse)
+async def download_text(pdf_id: str):
+    """Descarga el texto extraído de un PDF como archivo .txt."""
+    try:
+        pdf = await pdf_controller.get_pdf(pdf_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    text = pdf.extracted_text or ""
+    filename = f"{pdf.title}.txt"
+
+    return PlainTextResponse(
+        content=text,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"'
+        }
+    )

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -199,3 +199,29 @@ class TestExtractTextEndpoint:
 
         assert response.status_code == 404
         assert "Not found" in response.json()["detail"]
+        
+
+class TestDownloadEndpoint:
+    """Tests para el endpoint GET /api/pdfs/{pdf_id}/download."""
+
+    def test_download_returns_text_as_file(
+        self, client: TestClient, sample_pdf_bytes: bytes
+    ):
+        """Retorna el texto extraído como archivo descargable."""
+        create_response = client.post(
+            "/api/pdfs",
+            files={"file": ("doc.pdf", io.BytesIO(sample_pdf_bytes), "application/pdf")},
+            data={"title": "Mi Documento"},
+        )
+        pdf_id = create_response.json()["id"]
+
+        response = client.get(f"/api/pdfs/{pdf_id}/download")
+
+        assert response.status_code == 200
+        assert "attachment" in response.headers["content-disposition"]
+        assert "text/plain" in response.headers["content-type"]
+
+    def test_download_returns_404_when_pdf_not_found(self, client: TestClient):
+        """Retorna 404 cuando el PDF no existe."""
+        response = client.get("/api/pdfs/000000000000000000000000/download")
+        assert response.status_code == 404

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -303,3 +303,68 @@ class TestDeleteCommand:
             result = _cmd_delete(args)
 
             assert result == 1
+            
+
+class TestDownloadCommand:
+    """Tests para el subcomando 'download'."""
+
+    def test_download_saves_file_with_default_name(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """download guarda el texto en un archivo con el nombre del título."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "Contenido del PDF."
+        mock_response.headers = {
+            "content-disposition": 'attachment; filename="Mi Documento.txt"'
+        }
+
+        with patch("httpx.get", return_value=mock_response):
+            from dev.client.cli import _cmd_download
+            import argparse
+            import os
+
+            os.chdir(tmp_path)
+            args = argparse.Namespace(pdf_id="abc123", output=None)
+            result = _cmd_download(args)
+
+            assert result == 0
+            assert (tmp_path / "Mi Documento.txt").exists()
+
+    def test_download_saves_file_with_custom_name(
+        self, tmp_path: Path
+    ) -> None:
+        """--output permite especificar el nombre del archivo."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "Contenido del PDF."
+        mock_response.headers = {
+            "content-disposition": 'attachment; filename="Mi Documento.txt"'
+        }
+
+        output_file = tmp_path / "mi_archivo.txt"
+
+        with patch("httpx.get", return_value=mock_response):
+            from dev.client.cli import _cmd_download
+            import argparse
+
+            args = argparse.Namespace(pdf_id="abc123", output=output_file)
+            result = _cmd_download(args)
+
+            assert result == 0
+            assert output_file.exists()
+            assert output_file.read_text() == "Contenido del PDF."
+
+    def test_download_returns_1_when_pdf_not_found(self, capsys) -> None:
+        """download retorna código 1 si el ID no existe."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("httpx.get", return_value=mock_response):
+            from dev.client.cli import _cmd_download
+            import argparse
+
+            args = argparse.Namespace(pdf_id="id-inexistente", output=None)
+            result = _cmd_download(args)
+
+            assert result == 1


### PR DESCRIPTION
### Problema
No había forma de pedirle al servidor que descargue un .txt con el contenido subido a mongoDB.

### Solución
1.  Se agrego un endponit en `GET /api/pdfs/{pdf_id}/download` Retorna el texto como archivo descargable con headers Content-Disposition y Content-Type: text/plain. El texto ya está en MongoDB, es solo una lectura.

2.  Se agrego al CLI los comandos correspondientes:
  ```bash
  fast-pdf download <id>                    # guarda como <título>.txt
  fast-pdf download <id> --output mi.txt    # nombre personalizado
  ```

3. Se agregaron los test correspondientes:
- Test del endpoint en test_api.py — verifica que retorna 200 con el header correcto
- Test del subcomando en test_cli.py — mockea httpx y verifica que el archivo se crea

### Otros
Se actualizo el README según lo que pedia la issue #43.