### PR TITLE
feat(env): Se configuro el proyecto para usar un .env.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - MONGO_DB_NAME=pdf_manager
       # Esta variable ayuda a que Python no guarde archivos .pyc en el volumen
       - PYTHONDONTWRITEBYTECODE=1
+      - API_BASE_URL=http://localhost:8000 # Resuelve conflico con .env
     depends_on:
       mongodb:
         condition: service_healthy

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Base de datos MongoDB
+MONGO_URI=mongodb://localhost:27017
+MONGO_DB_NAME=pdf_manager
+
+# Límite de tamaño de archivos PDF (en MB)
+MAX_FILE_SIZE_MB=20
+
+# URL base de la API (usada por el CLI)
+API_BASE_URL=http://localhost:8000
+
+# Cada usuario tiene su propio .env, se recomienda copiar los datos de este y de ahi
+# poner configuraciones personales.

--- a/dev/config.py
+++ b/dev/config.py
@@ -7,14 +7,8 @@ class Settings(BaseSettings):
 
     MONGO_URI: str = "mongodb://localhost:27017"
     MONGO_DB_NAME: str = "pdf_manager"
-    UPLOAD_DIR: str = "./uploads"
 
-    # Tamaño máximo permitido para archivos PDF (en MB).
-    # Configurable vía variable de entorno MAX_FILE_SIZE_MB=20
     MAX_FILE_SIZE_MB: int = 10
-
-    # URL base de la API FastAPI a la que el CLI envía sus requests.
-    # Configurable vía variable de entorno: API_BASE_URL=http://servidor:8000
     API_BASE_URL: str = "http://localhost:8000"
 
     model_config = SettingsConfigDict(env_file=".env", extra="allow")

--- a/dev/config.py
+++ b/dev/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     MAX_FILE_SIZE_MB: int = 10
     API_BASE_URL: str = "http://localhost:8000"
 
+    # Esta linea es clave para sobreescribir la configuracion del entorno.
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 

--- a/dev/config.py
+++ b/dev/config.py
@@ -1,9 +1,19 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from importlib.metadata import version, PackageNotFoundError
 
+def get_version():
+    """
+    Consigue la version del programa desde el .toml
+    """
+    try:
+        return version("pdf-manager") 
+    
+    except PackageNotFoundError:    
+        return "unknown" # en caso de que no lo encuentre.
 
 class Settings(BaseSettings):
     APP_NAME: str = "PDF Manager"
-    VERSION: str = "1.0.0"
+    VERSION: str = get_version()
 
     MONGO_URI: str = "mongodb://localhost:27017"
     MONGO_DB_NAME: str = "pdf_manager"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-manager"
-version = "0.5.0"
+version = "1.0.0"
 description = "API para gestión de documentos PDF"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
### Problema
Las configuraciones y variables de entorno del proyecto estaban hardcodeadas en `config.py`  y no se podían modificar sin modificar el el código fuente.

### Solución
Se creo un `.env.example` con las configuraciones básicas del entorno, como se puede observar las configuraciones siguien figurando en `config.py` esto es por que son configuraciones base parte del código: 

`model_config = SettingsConfigDict(env_file=".env", extra="allow")`

Esta linea es clave para cargar el .env y sus configuraciones.

### Otros
- Se agrego una funcion `get_version` en `config.py` que le la version del proyecto en .toml.
- Tuve que hacer un rebase por la pr nueva, fue la forma mas limpia de manejarlo que encontre.
- Para copiar el archivo de ejemplo del entorno de puede usar `cp .env.example .env`