### PR TITLE
Agregue el infograma de la issue #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,10 @@ Esta organización permite mantener una separación clara entre código, pruebas
 
 ### Infograma
 
-Por completar :p
+![Infograma del sistema](docs/infograma.svg)
+
+> Una vista general del sistema en lenguaje no técnico: qué hace,
+> cómo fluye la información y desde dónde se puede usar.
 
 ### Diagrama de Clases
 

--- a/docs/infograma.puml
+++ b/docs/infograma.puml
@@ -1,1 +1,89 @@
 #infograma
+@startuml infograma
+skinparam backgroundColor #FAFAFA
+skinparam defaultFontName sans-serif
+skinparam defaultFontSize 13
+skinparam roundCorner 12
+skinparam shadowing false
+skinparam ArrowColor #455A64
+skinparam ArrowThickness 2
+
+skinparam rectangle {
+    BackgroundColor #E3F2FD
+    BorderColor #1565C0
+    FontColor #0D47A1
+    BorderThickness 2
+}
+
+skinparam card {
+    BackgroundColor #FFFFFF
+    BorderColor #90A4AE
+    FontColor #263238
+    BorderThickness 1.5
+}
+
+skinparam note {
+    BackgroundColor #FFF9C4
+    BorderColor #F9A825
+    FontColor #4E342E
+}
+
+title <b>pdf-extractext</b>\n<i>Extracción inteligente de texto desde documentos PDF</i>
+
+' ── CLIENTES ────────────────────────────────────────────────────────────────
+
+rectangle "🖥️  CLI\n<i>Terminal</i>" as CLI #D7F7D4/A5D6A7 {
+}
+
+rectangle "🌐  Navegador Web\n<i>Swagger / REST</i>" as WEB #D7F7D4/A5D6A7 {
+}
+
+rectangle "📱  App Móvil\n<i>Cualquier cliente HTTP</i>" as MOBILE #D7F7D4/A5D6A7 {
+}
+
+' ── API ──────────────────────────────────────────────────────────────────────
+
+rectangle "⚡  API Universal  —  FastAPI\n<b>Asincrónica · Cualquier cliente puede conectarse</b>\n<i>Recibe, valida y procesa cualquier solicitud HTTP</i>" as API #1565C0 {
+}
+
+' ── PROCESAMIENTO ───────────────────────────────────────────────────────────
+
+card "🔍  Validación real\n<b>Magic bytes %PDF-</b>\nNo alcanza con la extensión .pdf\nSe verifica el contenido real\nTamaño máximo configurable" as VAL
+
+card "🔒  Anti-duplicados\n<b>SHA-256 Checksum</b>\nCada archivo tiene una\nhuella digital única.\nSi ya fue subido, se avisa\nsin volver a procesarlo." as SHA
+
+card "📄  Extracción de texto\n<b>pypdf — modo layout</b>\nPreserva la estructura visual:\npárrafos, listas, indentación.\nSin escribir nada a disco." as EXTRACT
+
+' ── ALMACENAMIENTO ──────────────────────────────────────────────────────────
+
+rectangle "🍃  MongoDB\n<b>Base de datos no relacional</b>\nGuarda: texto extraído,\nchecksum SHA-256\ny metadatos del documento" as MONGO #E65100 {
+}
+
+' ── INFRAESTRUCTURA ─────────────────────────────────────────────────────────
+
+note as DOCKER
+  🐳  <b>Docker-ready</b>
+  Un solo comando levanta
+  el sistema completo.
+  Fácil de exportar a
+  cualquier servidor de producción.
+end note
+
+' ── FLUJO ───────────────────────────────────────────────────────────────────
+
+CLI    -right-> API : sube PDF
+WEB    -right-> API : sube PDF
+MOBILE -right-> API : sube PDF
+
+API -down-> VAL      : 1. Valida formato y tamaño
+VAL -right-> SHA     : 2. Calcula checksum
+SHA -right-> EXTRACT : 3. Extrae texto en memoria
+
+EXTRACT -down-> MONGO : 4. Persiste texto + checksum
+
+MONGO -left-> API : ✓ Respuesta al cliente
+
+DOCKER .up. API
+DOCKER .up. MONGO
+
+@enduml

--- a/docs/infograma.svg
+++ b/docs/infograma.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="960" height="620" viewBox="0 0 960 620">
+<defs>
+<marker markerWidth="7" markerHeight="6" viewBox="-1 -3 7 6" orient="auto" id="d0">
+<path d="M-1,-2 L-1,2 L4,0 Z" fill="#455A64" />
+</marker>
+</defs>
+<rect x="0" y="0" width="960" height="620" fill="#F8FAFC" />
+<rect x="0" y="0" width="960" height="56" fill="#1565C0" rx="0" />
+<text x="480.0" y="26" font-size="22" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#FFFFFF">pdf-extractext</text>
+<text x="480.0" y="47" font-size="12" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#BBDEFB">Extracción inteligente de texto desde documentos PDF</text>
+<rect x="22" y="85" width="150" height="85" fill="#E8F5E9" stroke="#43A047" stroke-width="2" rx="12" />
+<text x="97" y="111" font-size="13" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#1B5E20">🖥️ CLI</text>
+<text x="97" y="131" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">Terminal /</text>
+<text x="97" y="147" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">Línea de comandos</text>
+<rect x="22" y="210" width="150" height="85" fill="#E8F5E9" stroke="#43A047" stroke-width="2" rx="12" />
+<text x="97" y="236" font-size="13" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#1B5E20">🌐 Web</text>
+<text x="97" y="256" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">Navegador /</text>
+<text x="97" y="272" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">Swagger UI</text>
+<rect x="22" y="335" width="150" height="85" fill="#E8F5E9" stroke="#43A047" stroke-width="2" rx="12" />
+<text x="97" y="361" font-size="13" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#1B5E20">📱 Móvil</text>
+<text x="97" y="381" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">Cualquier</text>
+<text x="97" y="397" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#2E7D32">cliente HTTP</text>
+<path d="M174,127 L250,127" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M174,252 L250,252" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M174,377 L250,377" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<rect x="252" y="80" width="168" height="350" fill="#1565C0" stroke="#0D47A1" stroke-width="2" rx="16" />
+<text x="336" y="108" font-size="14" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#FFFFFF">⚡ API Universal</text>
+<text x="336" y="128" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#90CAF9">FastAPI — Asincrónica</text>
+<text x="336" y="150" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#BBDEFB">Cualquier cliente HTTP</text>
+<text x="336" y="168" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#BBDEFB">puede conectarse</text>
+<path d="M264,184 L408,184" stroke="#42A5F5" stroke-width="1" stroke-dasharray="4,3" />
+<text x="336" y="202" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#90CAF9">Endpoints disponibles:</text>
+<text x="336" y="220" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#E3F2FD">POST /api/pdfs</text>
+<text x="336" y="242" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#E3F2FD">GET /api/pdfs</text>
+<text x="336" y="264" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#E3F2FD">GET /{id}/text</text>
+<text x="336" y="286" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#E3F2FD">GET /{id}/download</text>
+<text x="336" y="308" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#E3F2FD">DELETE /{id}</text>
+<path d="M422,127 L478,127" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M422,252 L478,252" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M422,377 L478,377" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<rect x="480" y="85" width="220" height="85" fill="#FFFFFF" stroke="#90A4AE" stroke-width="2" rx="10" />
+<text x="590" y="105" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#0D47A1">🔍 1. Validación real</text>
+<text x="590" y="123" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Magic bytes %PDF-</text>
+<text x="590" y="139" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">No basta la extensión .pdf</text>
+<text x="590" y="155" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Tamaño máximo configurable</text>
+<rect x="480" y="210" width="220" height="85" fill="#FFFFFF" stroke="#90A4AE" stroke-width="2" rx="10" />
+<text x="590" y="230" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#0D47A1">🔒 2. Anti-duplicados SHA-256</text>
+<text x="590" y="248" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Huella digital única</text>
+<text x="590" y="264" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">por contenido del archivo</text>
+<text x="590" y="280" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Duplicados rechazados sin reprocesar</text>
+<rect x="480" y="335" width="220" height="85" fill="#FFFFFF" stroke="#90A4AE" stroke-width="2" rx="10" />
+<text x="590" y="355" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#0D47A1">📄 3. Extracción de texto</text>
+<text x="590" y="373" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">pypdf — modo layout</text>
+<text x="590" y="389" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Preserva párrafos, listas</text>
+<text x="590" y="405" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#455A64">Sin escribir nada al disco</text>
+<path d="M590,170 L590,210" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M590,295 L590,335" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<path d="M702,377 L758,377" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<rect x="760" y="220" width="176" height="160" fill="#FFF3E0" stroke="#E65100" stroke-width="2" rx="16" />
+<text x="848" y="248" font-size="14" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#BF360C">🍃 MongoDB</text>
+<text x="848" y="268" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#E65100">No relacional</text>
+<path d="M772,282 L924,282" stroke="#FFCC80" stroke-width="1" />
+<text x="848" y="300" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#4E342E">✓ Texto extraído</text>
+<text x="848" y="318" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#4E342E">✓ Checksum SHA-256</text>
+<text x="848" y="336" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#4E342E">✓ Metadatos del PDF</text>
+<text x="848" y="354" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#4E342E">✓ Título y tamaño</text>
+<path d="M848,220 L848,192" stroke="#78909C" stroke-width="1.5" stroke-dasharray="5,3" />
+<path d="M420,192 L848,192" stroke="#78909C" stroke-width="1.5" stroke-dasharray="5,3" />
+<path d="M420,192 L420,254" stroke="#455A64" stroke-width="2.2" marker-end="url(#d0)" />
+<text x="634" y="185" font-size="10" text-anchor="middle" font-family="Arial, sans-serif" fill="#546E7A" font-style="italic">✓ Respuesta al cliente</text>
+<rect x="252" y="458" width="684" height="68" fill="#E3F2FD" stroke="#1976D2" stroke-width="2" rx="12" />
+<text x="594" y="482" font-size="13" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#0D47A1">🐳  Docker-ready</text>
+<text x="594" y="502" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="normal" fill="#1565C0">Un solo comando levanta el sistema completo.  Fácil de desplegar en cualquier servidor de producción.</text>
+<rect x="22" y="450" width="212" height="136" fill="#FAFAFA" stroke="#CFD8DC" stroke-width="2" rx="10" />
+<text x="128" y="470" font-size="11" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" fill="#455A64">Características</text>
+<path d="M32,478 L222,478" stroke="#CFD8DC" stroke-width="1" />
+<text x="34" y="494" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">⚡ Procesamiento asincrónico</text>
+<text x="34" y="510" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">🔒 SHA-256 anti-duplicados</text>
+<text x="34" y="526" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">🍃 MongoDB no relacional</text>
+<text x="34" y="542" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">📄 Layout preservado</text>
+<text x="34" y="558" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">🐳 Docker-ready</text>
+<text x="34" y="574" font-size="9" text-anchor="start" font-family="Arial, sans-serif" font-weight="normal" fill="#37474F">🌐 API universal (CLI/Web/Móvil)</text>
+</svg>


### PR DESCRIPTION
## Contexto
 
El proyecto contaba con documentación técnica de calidad (diagrama de clases UML, diagrama de secuencia) pero nada orientado a un usuario no técnico o cliente. Alguien que no conoce Python, FastAPI ni MongoDB no podía entender qué hace el sistema con solo leer el README. Esta PR agrega una infografía en lenguaje natural que comunica el valor del sistema, su flujo de datos y sus características principales, y la integra al README siguiendo exactamente la misma convención que los otros diagramas del proyecto.
 
---
 
## Qué se comunica en la infografía
 
El diagrama responde en una sola vista las tres preguntas que haría cualquier usuario no técnico:
 
**¿Desde dónde puedo usarlo?** — Desde cualquier lugar: CLI (terminal), navegador web vía Swagger, o cualquier app móvil u otro cliente HTTP. La API es universal.
 
**¿Qué hace cuando le mando un PDF?** — Cuatro pasos en orden:
1. Valida que el archivo sea realmente un PDF (no alcanza con que tenga extensión `.pdf` — se verifican los magic bytes internos) y que no supere el tamaño máximo configurado.
2. Calcula una huella digital SHA-256 del contenido. Si ese PDF ya fue subido antes, lo detecta y avisa sin reprocesar nada.
3. Extrae el texto respetando la estructura visual del documento: párrafos, listas, indentación. Todo en memoria, sin escribir nada al disco.
4. Guarda el texto extraído, el checksum y los metadatos en MongoDB.
**¿Dónde viven los datos?** — En MongoDB, una base de datos no relacional que almacena texto extraído, checksum SHA-256, título y tamaño de cada documento.
 
Además se hace énfasis en que todo el sistema se levanta con un solo comando Docker, lo que lo hace fácil de desplegar en cualquier servidor de producción.
 
---
 
## Archivos
 
### `docs/infograma.puml` — el diagrama fuente
 
Se reemplazó el comentario vacío `#infograma` que existía en el archivo con el diagrama completo en sintaxis PlantUML. Se usaron los mismos tipos de componentes (`rectangle`, `card`, `note`) y la misma convención de `skinparam` que los otros dos diagramas del proyecto, para mantener coherencia visual en la carpeta `docs/`.
 
El layout es de izquierda a derecha en cuatro columnas que representan las capas del sistema:
 
```
[Clientes]  →  [API Universal]  →  [Procesamiento]  →  [MongoDB]
  CLI               FastAPI          1. Validación
  Web             Asincrónica        2. SHA-256
  Móvil                              3. Extracción
```
 
El flujo de retorno al cliente se marca con una línea punteada por encima del diagrama para no interrumpir el flujo principal. Docker aparece como una nota anclada en la zona de infraestructura, igual que el ejemplo de referencia provisto en la issue.
 
### `docs/infograma.svg` — el render exportado
 
Sigue exactamente la misma convención que `diagrama_clases.svg` y `diagrama_secuencia.svg`: mismo directorio `docs/`, mismo nombre base que el `.puml` correspondiente. El SVG se commitea al repositorio para que GitHub lo renderice directamente en el README sin requerir ninguna herramienta adicional.
 
### `README.md` — integración en la sección de Diagramas UML
 
Se reemplazó la línea `Por completar :p` que existía bajo `### Infograma` con la imagen embebida:
 
```markdown
### Infograma
 
![Infograma del sistema](docs/infograma.svg)
 
> Una vista general del sistema en lenguaje no técnico: qué hace,
> cómo fluye la información y desde dónde se puede usar.
```
 
El patrón `![título](docs/archivo.svg)` es idéntico al que ya usan `diagrama_clases.svg` y `diagrama_secuencia.svg` más abajo en la misma sección.
 
---
 
## Características comunicadas
 
| Característica | Cómo aparece en el diagrama |
|---|---|
| API universal | Tres clientes (CLI, Web, Móvil) apuntando al mismo bloque central |
| Asincrónico | Etiqueta explícita en el bloque de API |
| Validación real | Paso 1 con descripción de magic bytes y tamaño |
| SHA-256 anti-duplicados | Paso 2 con descripción en lenguaje no técnico |
| Extracción sin tocar el disco | Paso 3, menciona "sin escribir nada al disco" |
| MongoDB no relacional | Bloque dedicado con los campos que persiste |
| Docker-ready | Nota anclada en la zona de infraestructura |
 
---
 
## Archivos modificados
 
| Archivo | Acción |
|---|---|
| `docs/infograma.puml` | Reemplazado — diagrama completo en PlantUML |
| `docs/infograma.svg` | Nuevo — render exportado para GitHub |
| `README.md` | Modificado — sección Infograma con imagen embebida |

close #52 