### PR TITLE
fix(docker): quite linea repetida #65

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Directorio de trabajo interno
 WORKDIR /app
 
-# Copiar archivos de dependencias y el código de la app.
+# Copiar los archivos de bloqueo Y el README requerido por el backend de compilación
 COPY pyproject.toml uv.lock README.md ./
-COPY dev/ ./dev
 
 # Copiar el código fuente
 COPY dev/ ./dev
 
-# Instalar las dependencias directamente en el entorno del contenedor
-RUN uv pip install --system --no-cache .
+# Instalar usando el uv.lock de forma exacta (crea /app/.venv)
+RUN uv sync --frozen --no-dev --no-editable
 
 # SEGURIDAD: Crear usuario no-root para ejecución segura.
 RUN useradd -u 10001 -m appuser && chown -R appuser:appuser /app
@@ -23,5 +22,5 @@ USER appuser
 # Exponer el puerto nativo de FastAPI.
 EXPOSE 8000
 
-# Comando de arranque para producción.
-CMD ["uvicorn", "dev.servers.app:app", "--host", "0.0.0.0", "--port", "8000"]
+# Comando de arranque apuntando al entorno virtual generado por uv
+CMD ["/app/.venv/bin/uvicorn", "dev.servers.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/uv.lock
+++ b/uv.lock
@@ -222,8 +222,8 @@ wheels = [
 ]
 
 [[package]]
-name = "pdf-manager"
-version = "1.0.0"
+name = "parsedocumentsfast"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beanie" },


### PR DESCRIPTION
### Resuelto

Este PR corrige el fallo en el pipeline de construcción de Docker causado por cambios recientes en la estructura y empaquetado del proyecto.
Cambios realizados:

- Actualización de dependencias: Se corrió uv lock para sincronizar el archivo de bloqueo con el nuevo nombre del paquete del workspace (parsedocumentsfast).

- Ajuste en Dockerfile: Se incluyó el archivo README.md en la instrucción COPY. Esto es necesario porque el backend de empaquetado (hatchling) exige la presencia del archivo para validar los metadatos del proyecto durante el comando uv sync.