### PR TITLE
feat: Implementar Traefik #72 #73 #74 #75

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@
 # Excluir configuraciones locales de desarrollo
 .devcontainer/
 
+# Infraestructura / Traefik
+.infra/certs/*.pem
+.infra/certs/*.key
+.infra/certs/*.crt
+!.infra/certs/.gitkeep
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/.infra/certs/README.md
+++ b/.infra/certs/README.md
@@ -1,0 +1,10 @@
+# Importante
+
+*Cada computadora debe tener certificados independientes*. Descargue `mkcert` y ejecute lo siguiente:
+
+```bash
+cd .infra/certs
+mkcert "pdfmanager.local" "*.pdfmanager.local"
+mv pdfmanager.local+1.pem pdfmanager.pem
+mv pdfmanager.local+1-key.pem pdfmanager-key.pem
+```

--- a/.infra/config/config.yml
+++ b/.infra/config/config.yml
@@ -1,0 +1,18 @@
+http:
+  routers:
+    # Router para el Dashboard de Traefik
+    traefik-dashboard:
+      rule: "Host(`api.pdfmanager.local`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+      service: "api@internal"  # Servicio nativo de Traefik
+      entryPoints:
+        - https
+      tls:
+        domains:
+          - main: "pdfmanager.local"
+            sans:
+              - "*.pdfmanager.local"
+
+tls:
+  certificates:
+    - certFile: "/etc/certs/pdfmanager.pem"
+      keyFile: "/etc/certs/pdfmanager-key.pem"

--- a/.infra/config/traefik.yml
+++ b/.infra/config/traefik.yml
@@ -1,0 +1,25 @@
+global:
+  sendAnonymousUsage: true
+
+api:
+  dashboard: true
+  insecure: false
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    watch: true
+    exposedByDefault: false
+  file:
+    filename: /etc/traefik/config.yml
+    watch: true
+
+log:
+  level: INFO
+  format: common
+
+entryPoints:
+  redis:
+    address: ":6379"
+  https:
+    address: ":443"

--- a/.infra/docker-compose.infra.yml
+++ b/.infra/docker-compose.infra.yml
@@ -1,0 +1,26 @@
+services:
+  reverse-proxy:
+    image: traefik:v3.5
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "443:443"      # Único puerto de entrada web (HTTPS)
+      - "6379:6379"    # Redis expuesto para dev
+      - "27017:27017"  # Mongo expuesto para dev
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./config/config.yml:/etc/traefik/config.yml:ro
+      - ./certs:/etc/certs:ro
+    networks:
+      - fast_pdf_network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik=true"
+
+networks:
+  fast_pdf_network:
+    name: fast_pdf_network
+    driver: bridge

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,10 +5,10 @@
 services:
   mongodb:
     image: mongo:7-jammy
-    ports:
-      - "27017:27017"
+  # ports:
+  #  - "27017:27017"
     networks:
-      - pdf_network  
+      - pdf_internal_network  
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
@@ -28,7 +28,8 @@ services:
       - MONGO_URI=mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongodb:27017/?authSource=admin
       - MONGO_DB_NAME=${MONGO_DB_NAME}
     networks:
-      - pdf_network  
+      - pdf_internal_network
+      - fast_pdf_network 
 
 volumes:
   mongodb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,17 @@ services:
     env_file:
       - .env
     networks:
-      - pdf_network  
+          - pdf_internal_network  # Red privada exclusiva para App <-> Mongo
+          - fast_pdf_network       # Red externa compartida con Traefik
+    labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.pdf-app.rule=Host(`api.pdfmanager.local`)"
+        - "traefik.http.routers.pdf-app.entrypoints=https"
+        - "traefik.http.routers.pdf-app.tls=true"
+        - "traefik.http.services.pdf-app.loadbalancer.server.port=8000" 
 
 networks:
-  pdf_network:       
-    external: true
+    pdf_internal_network:
+      driver: bridge
+    fast_pdf_network:
+      external: true


### PR DESCRIPTION
# Implementación de Traefik

## Problema

Se necesitaba configurar Traefik en el proyecto actual, crear "labels", configurar certificados y levantar el contenedor de traefik. 

## Resuelto

### Estructura

La configuración debería ir por separado del proyecto, pero por temas de distribución se elegió poner la configuración de traefik en la carpeta `.infra/`. Esto se puede quitar y dejar como una configuración local. 

### docker-compose

Se dejaron dos redes, `pdf_internal_network` y `fast_pdf_network`. La primera es como los contenedores se comunicaran entre si, y la ultima es como Traefik se expondrá al exterior.

### Puertos

Se quito los puertos necesarios y se agrego  `443` para `https`, `6379` *para agregar Redis futuramente* y `27017` para el contenedor de `MongoDB`.

### Certificados

En la carpeta `/certs` hay un `README.md` de como crear los certificados para la computadora, tambien se agrego al `.gitignore` la misma carpeta, **los certificados no pueden compartirse.**

### Resumen

Traefik queda expuesto en el puerto `443` esperando solicitudes para repartirlas entre los contenedores, esto toma fuerza cuando hayan mas microservicios. La red interna queda para que los contenedores se comuniquen entre si.

## Problemas conocidos

- No se ha testeado el uso de la app actualmente.
- Dashboard de traefik no funciona.
- Falta documentación sobre como levantar la app.