### PR TITLE
feat(whoami): se agrego el whoami a la red

### DIFF
--- a/.infra/docker-compose.infra.yml
+++ b/.infra/docker-compose.infra.yml
@@ -4,7 +4,7 @@ services:
     container_name: traefik
     environment:
     # Modficar en caso de que su Docker Engine no soporte -> docker version --format '{{.Server.APIVersion}}'
-      - DOCKER_API_VERSION=1.55
+      - DOCKER_API_VERSION=1.40
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/.infra/docker-compose.infra.yml
+++ b/.infra/docker-compose.infra.yml
@@ -2,6 +2,9 @@ services:
   reverse-proxy:
     image: traefik:v3.5
     container_name: traefik
+    environment:
+    # Modficar en caso de que su Docker Engine no soporte -> docker version --format '{{.Server.APIVersion}}'
+      - DOCKER_API_VERSION=1.55
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -10,10 +13,10 @@ services:
       - "6379:6379"    # Redis expuesto para dev
       - "27017:27017"  # Mongo expuesto para dev
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./config/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./config/config.yml:/etc/traefik/config.yml:ro
-      - ./certs:/etc/certs:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro,z
+      - ./config/traefik.yml:/etc/traefik/traefik.yml:ro,z
+      - ./config/config.yml:/etc/traefik/config.yml:ro,z
+      - ./certs:/etc/certs:ro,z
     networks:
       - fast_pdf_network
     labels:

--- a/.infra/whoami/docker-compose.yml
+++ b/.infra/whoami/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  whoami:
+    deploy:
+      replicas: 5
+    image: traefik/whoami
+    security_opt:
+      - no-new-privileges:true
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whoami.rule=Host(`whoami.pdfmanager.local`)"
+      - "traefik.http.routers.whoami.entrypoints=https"
+      - "traefik.http.routers.whoami.tls=true"
+      - "traefik.http.services.whoami.loadbalancer.server.port=80"
+    networks:
+      - fast_pdf_network
+
+networks:
+  fast_pdf_network:
+    external: true


### PR DESCRIPTION
# Whoami

Un whoami es un pequeño programa que devuelve datos del servidor físico que esta realizando la ejecución en ese momento.

## Agregado

Se agrego una carpeta `.infra/whoami` donde hay un docker-compose con la imagen estandar de whoami para traefik. El mismo se levanta como otra instancia de la red del proyecto y responde a `https://whoami.pdfmanager.local`.

## Problemas conocidos

Versiones de Docker muy nuevas o configuraciones complejas como SELinux pueden generar errores:

``` bash
2026-07-24T20:22:41Z ERR Provider error, retrying in 346.94909ms error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version" providerName=docker
```

El error persiste a pesar de especificar un entorno mas nuevo de la API en `.infra/docker-compose.infra.yml` :

```yml
  reverse-proxy:
    image: traefik:v3.5
    container_name: traefik
    environment:
    # Modficar en caso de que su Docker Engine no soporte -> docker version --format '{{.Server.APIVersion}}'
      - DOCKER_API_VERSION=1.55
      .....
```

Esto genera errores como que el whoami de un error 404 al consultarlo.
