### PR TITLE
fix(traefik): Arreglado error de traefik-docker

### DIFF
--- a/.infra/docker-compose.infra.yml
+++ b/.infra/docker-compose.infra.yml
@@ -1,10 +1,7 @@
 services:
   reverse-proxy:
-    image: traefik:v3.5
+    image: traefik:v3.6.1 # Version con fix.
     container_name: traefik
-    environment:
-    # Modficar en caso de que su Docker Engine no soporte -> docker version --format '{{.Server.APIVersion}}'
-      - DOCKER_API_VERSION=1.40
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
# Problema

Docker arrojaba este error y no permitía iniciar Traefik:

``` bash
2026-07-27T22:38:42Z ERR Provider error, retrying in 1.841223153s error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.40, please upgrade your client to a newer version" providerName=docker
```

Esto se debía a que la imagen de `traefik:3.5` era demasiado vieja y usaba el entorno 1.24, mientras que builds nuevas de Docker piden 1.40.

## Solucion

Sencillamente importar una build de  traefik mas nueva como `traefik:3.6.1`.

<img width="1365" height="644" alt="image" src="https://github.com/user-attachments/assets/faf0246d-949f-45b8-951a-ed5a137b2fe0" />

## Extra

- Borrar cada contenedor usando `down` y la flag `-v` para evitar errores por cache, Ejemplo: `docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v `