### PR TITLE
fix(certs):Se arreglo el .env y tema certificados.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,5 @@ MAX_FILE_SIZE_MB=20
 # Debe apuntar a la URL pública o privada donde el servidor FastAPI sea accesible.
 # En desarrollo: http://localhost:8000
 # En producción: Cambiar por el dominio/IP del despliegue (ej: http://api.tuservicio.com)
-API_BASE_URL=http://localhost:8000
+
+API_BASE_URL=https://api.pdfmanager.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .agents/
 .skills-lock.json
 
+# scripts locales
+run.sh
+
 # Excluir configuraciones locales de desarrollo
 .devcontainer/
 


### PR DESCRIPTION
# Contexto

Del problema #92 y tema de certificados hay dos soluciones.

## Entorno

Se apunto la URL a `API_BASE_URL=https://api.pdfmanager.local`, para que pase por traefik y se cumpla el ciclo.

## Certificados

Python falla encontrando los certificados localmente, la solución a esto puede diferir según el caso, pero una vez creado los certificados con `mkcerts`, esto me fue util: 

``` bash
❯ openssl x509 -in .infra/certs/pdfmanager.pem -noout -subject -issuer
subject=O=mkcert development certificate, OU=fotengame656@fedora (José Morata)
issuer=O=mkcert development CA, OU=fotengame656@fedora (José Morata), CN=mkcert fotengame656@fedora (José Morata)
PDF-project on  env/archivo_viejo [!] is 📦 v1.2.0 via 🐍 v3.14.6 
❯ mkcert -CAROOT
/home/fotengame656/.local/share/mkcert
PDF-project on  env/archivo_viejo [!] is 📦 v1.2.0 via 🐍 v3.14.6 
❯ export SSL_CERT_FILE="$(mkcert -CAROOT)/rootCA.pem"
```

## Extra

- Modificado el gitignore para un script local. 